### PR TITLE
Update BootstrapColorPickerPickerField.php

### DIFF
--- a/src/Field/BootstrapColorPickerPickerField.php
+++ b/src/Field/BootstrapColorPickerPickerField.php
@@ -2,9 +2,9 @@
 
 namespace sahassar\bootstrapcolorpicker\Field;
 
-use Bolt\Storage\Field\FieldInterface;
+use Bolt\Storage\Field\Type\FieldTypeBase;
 
-class BootstrapColorPickerPickerField implements FieldInterface
+class BootstrapColorPickerPickerField extends FieldTypeBase
 {
 
     public function getName()


### PR DESCRIPTION
I needed to change the class to extend the FieldTypeBase otherwise the field wouldn't save into the database.
I guess this occurs since Bolt 3.3 because the save mechanism for custom fields had changed. 

Also, the interface FieldTypeBase shouldn't be necessary in this context anymore because the FieldTypeBase itself uses it already.