### PR TITLE
Fix column default value for MySQL database

### DIFF
--- a/src/Field/BootstrapColorPickerPickerField.php
+++ b/src/Field/BootstrapColorPickerPickerField.php
@@ -24,6 +24,6 @@ class BootstrapColorPickerPickerField extends FieldTypeBase
 
     public function getStorageOptions()
     {
-        return ['default'=>''];
+        return ['default'=>null];
     }
 }


### PR DESCRIPTION
Setting column default value to `""` failed quietly every time on database update making it impossible to update the schema. The notification about database need to be fixed/updated was constantly showing. When trying to do that update with PHPStorm I detected that this update triggers an error from database:

> [42000][1101] BLOB, TEXT, GEOMETRY or JSON column 'theme_color' can't have a default value

After quick research I found that in MySQL databases it is not possible to set default values for some kind of fields to string. This PR fixes the problem by changing default value to NULL.