### PR TITLE
Add default values for field options

### DIFF
--- a/templates/_bootstrap-colorpicker.twig
+++ b/templates/_bootstrap-colorpicker.twig
@@ -1,5 +1,12 @@
 {#=== Options ============================================================================#}
 
+{% set field = {
+    hidden: false,
+    inline: false,
+    horizontal: true,
+    component: true
+} | merge(field) %}
+
 {% set attr_opt = {
 class:              'form-control '~field.class|default(''),
 name_id:            key,


### PR DESCRIPTION
So without setting some options in the `contenttypes.yml` I was getting errors about missing keys in field object. This fixes it with setting default values – they give a nice input with the button on right side. I didn't use the `default` filter because it overwrites values when they are equal to `false` which would not work here: `false` may be a valid setting. Instead I created a object with default values and merged the field options to it.