### PR TITLE
Default to an empty string, rather than null

### DIFF
--- a/src/Field/BootstrapColorPickerPickerField.php
+++ b/src/Field/BootstrapColorPickerPickerField.php
@@ -24,6 +24,6 @@ class BootstrapColorPickerPickerField extends FieldTypeBase
 
     public function getStorageOptions()
     {
-        return ['default'=>null];
+        return ['default' => ''];
     }
 }


### PR DESCRIPTION
This fixes an error thrown (when updating a SQLite db) when you repurpose a `text` field to a `bootstrapcolorpicker` one.