### PR TITLE
Bug/Feature in doctrine makes bolt's db check fail every time

### DIFF
--- a/src/Field/BootstrapColorPickerPickerField.php
+++ b/src/Field/BootstrapColorPickerPickerField.php
@@ -24,6 +24,6 @@ class BootstrapColorPickerPickerField extends FieldTypeBase
 
     public function getStorageOptions()
     {
-        return ['default' => ''];
+        return ['notnull' => false];
     }
 }


### PR DESCRIPTION
A bug in doctrines handling of default column options makes bolt's database check fail everytime. 
This change applies the proper default value for mysql tables.